### PR TITLE
MinibrowserListItem.vue adding the value property for extra functionality

### DIFF
--- a/src/components/Minibrowser/components/MinibrowserListItem.vue
+++ b/src/components/Minibrowser/components/MinibrowserListItem.vue
@@ -25,6 +25,9 @@ export default {
   inject: ['browserContext'],
 
   props: {
+    value: {
+      required: false,
+    },
     as: {
       type: String,
       default: 'a',


### PR DESCRIPTION
These changes allow for more flexibility in handling the handleClick event.

For example: I have a tree of directories. I provide a full path as value. I want to get the full path when I select an item.

```js
// SbMinibrowser the options property that provided
[
    {
        "label": "f",
        "isParent": true,
        "items": [
            {
                "label": "g",
                "isParent": true,
                "items": [
                    {
                        "label": "h",
                        "isParent": true,
                        "items": [
                            {
                                "label": "k",
                                "value": "f/g/h/k"
                            }
                        ]
                    }
                ]
            }
        ]
    },
    {
        "label": "a",
        "isParent": true,
        "items": [
            {
                "label": "b",
                "isParent": true,
                "items": [
                    {
                        "label": "c",
                        "value": "a/b/c"
                    },
                    {
                        "label": "d",
                        "value": "a/b/d"
                    }
                ]
            },
            {
                "label": "e",
                "value": "a/e"
            }
        ]
    },
    {
        "label": "b",
        "value": "b"
    }
]
```